### PR TITLE
Add dark mode support

### DIFF
--- a/assets/scss/_dark.scss
+++ b/assets/scss/_dark.scss
@@ -1,0 +1,18 @@
+$bg_color: #2d2c2c;
+$dark_table_color: #201f1f;
+@media (prefers-color-scheme: dark) {
+  body {
+    background: $bg_color;
+    color: #ffffff !important;
+  }
+  .post__footer__author,
+  .author__info {
+    background: $dark_table_color;
+  }
+  .footer {
+    filter: invert(100%);
+  }
+  .has-background {
+    background: $bg_color !important;
+  }
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -15,7 +15,7 @@ Tags: stc
 
 // fabric theme
 // ===============================================
-@import "fabric/_Fabric.scss";   
+@import "fabric/_Fabric.scss";
 
 // variables
 // ===============================================
@@ -61,3 +61,6 @@ Tags: stc
 // ===============================================
 @import "_author.scss";
 
+// dark.scss
+// ===============================================
+@import "_dark.scss";


### PR DESCRIPTION
Add dark mode styles and load them with the `@media (prefers-color-scheme: dark)` feature so the website gets automatically switched from light to dark (or vice versa) depending on the current system setting.